### PR TITLE
CMake and texture object support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,81 @@
+####################################################################################
+# START 1. Basic setup for cmake
+####################################################################################
+
+# basic setup for cmake
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
+set(CMAKE_COLOR_MAKEFILE ON)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+# Disable gnu exentions
+set(CMAKE_CXX_EXTENSIONS ON)
+
+# Define the project
+project("dedisp" VERSION 1.0.0 LANGUAGES CXX CUDA C)
+
+# DEDISP may be built to run using CUDA. Future version may be
+# written for HIP or SYCL, which we call the
+# Target type. By default, the target is CUDA.
+if(DEFINED ENV{DEDISP_TARGET})
+  set(DEFTARGET $ENV{DEDISP_TARGET})
+else()
+  set(DEFTARGET "CUDA")
+endif()
+
+set(VALID_TARGET_TYPES CUDA) #HIP SYCL
+set(DEDISP_TARGET_TYPE
+  "${DEFTARGET}"
+  CACHE STRING "Choose the type of target, options are: ${VALID_TARGET_TYPES}")
+set_property(CACHE DEDISP_TARGET_TYPE PROPERTY STRINGS CUDA)
+
+# CUDA specific part of CMakeLists
+#set(CMAKE_CUDA_EXTENSIONS OFF)
+find_package(CUDAToolkit REQUIRED)
+
+string(TOUPPER ${DEDISP_TARGET_TYPE} CHECK_TARGET_TYPE)
+list(FIND VALID_TARGET_TYPES ${CHECK_TARGET_TYPE} TARGET_TYPE_VALID)
+
+if(TARGET_TYPE_VALID LESS 0)
+  message(SEND_ERROR "Please specify a valid DEDISP_TARGET_TYPE type! Valid target types are:" "${VALID_TARGET_TYPES}")
+endif()
+
+# Git
+find_package(Git)
+if(GIT_FOUND)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} show
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    RESULT_VARIABLE IS_GIT_REPOSIITORY
+    OUTPUT_QUIET ERROR_QUIET)
+  if(${IS_GIT_REPOSIITORY} EQUAL 0)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} describe --abbrev=0
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE GITTAG
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    # we use git rev-list and pipe that through wc here. Newer git versions support --count as option to rev-list but
+    # that might not always be available
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} rev-list ${GITTAG}..HEAD
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      COMMAND wc -l
+      OUTPUT_VARIABLE GITCOUNT
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} describe --match 1 --always  --long --dirty
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE GITVERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
+endif(GIT_FOUND)
+
+
+# Add src, tests
+add_subdirectory(src)
+add_subdirectory(example)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ if(GIT_FOUND)
   endif()
 endif(GIT_FOUND)
 
+option(DEDISP_TEXTURE "Use texture support (reference/obj)" ON)
+add_compile_definitions(DEDISP_USE_TEXTURE=${DEDISP_USE_TEXTURE} DEDISP_TEXTURE)
 
 # Add src, tests
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,22 @@ endif(GIT_FOUND)
 option(DEDISP_TEXTURE "Use texture support (reference/obj)" ON)
 add_compile_definitions(DEDISP_USE_TEXTURE=${DEDISP_USE_TEXTURE} DEDISP_TEXTURE)
 
+option(DEDISP_BUILD_TESTS "Build test suite" ON)
+
 # Add src, tests
 add_subdirectory(src)
-add_subdirectory(example)
+
+if(DEDISP_BUILD_TESTS)
+  add_subdirectory(example)
+endif()
+
+# Install project cmake targets
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  ${PROJECT_NAME}-config-version.cmake
+  VERSION ${DEDISP_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake/${PROJECT_NAME}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,19 @@ option(DEDISP_TEXTURE "Use texture support (reference/obj)" ON)
 add_compile_definitions(DEDISP_USE_TEXTURE=${DEDISP_USE_TEXTURE} DEDISP_TEXTURE)
 
 option(DEDISP_BUILD_TESTS "Build test suite" ON)
+option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+
+# Print the configuration details to stdout
+message(STATUS "")
+message(STATUS "${PROJECT_NAME} ${PROJECT_VERSION} (${GITVERSION}) **")
+message(STATUS "cmake version: ${CMAKE_VERSION}")
+message(STATUS "Source location: ${CMAKE_SOURCE_DIR}")
+message(STATUS "Build location: ${CMAKE_BINARY_DIR}")
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "DEDISP target: ${DEDISP_TARGET_TYPE}")
+message(STATUS "DEDISP texture: ${DEDISP_TEXTURE}")
+message(STATUS "DEDISP build tests: ${DEDISP_BUILD_TESTS}")
+message(STATUS "DEDISP build shared libs: ${BUILD_SHARED_LIBS}")
 
 # Add src, tests
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repositry is derived from Ben Barsdell's original GPU De-dedispersion libra
 
 Installation Instructions (CMake):
 
-Using command line CMake
+## Using command line CMake
 
   1. `git clone https://github.com/ajameson/dedisp.git`
   2. `mkdir build; cd build`
@@ -26,7 +26,7 @@ Last, make (and install) the componenets
 
   4. `make -j install`
 
-Using Makefile
+## Using Makefile
 
   1.  `git clone https://github.com/ajameson/dedisp.git`
   2.  Update `Makefile.inc` with your CUDA path, Install Dir and GPU architecture. e.g.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ and optional install path
 
   3. `cmake -DDEDISP_USE_TEXTURE=ON \
             -DDEDISP_BUILD_TESTS=ON \
+            -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_CUDA_ARCHITECTURES=70 \
             -DCMAKE_INSTALL_PREFIX="/scratch/CPviolator/work/DSA110/dedisp_local/install" \
             -DCMAKE_CUDA_COMPILER="/path/to/nvcc" ../dedisp`
@@ -34,4 +35,4 @@ Using Makefile
       * `GPU_ARCH = sm_60`
   3.  `make && make install`
   
-  Either of these will build a shared object library named `libdedisp.so` which is a prerequisite for Heimdall. The dedisp header files will be installed into `INSTALL_DIR/include`, the test and runtime library into `INSTALL_DIR/lib` and the test executable into `INSTALL_DIR/bin`. The `CMake` method will build a static libray `libdedisp.a` in addition to `libdedisp.so` 
+  Either of these will build a shared object library named `libdedisp.so` which is a prerequisite for Heimdall. The dedisp header files will be installed into `INSTALL_DIR/include`, the test and runtime library into `INSTALL_DIR/lib`. The CMake method will build static libraries `libdedisp.a, libdedisp_test.a` or a shared libraries `libdedisp.so, libdedisp_test.so` via the CMake variable `BUILD_SHARED_LIBS`. Install locations are unchanged, with the additions that the test executable will be placed into `INSTALL_DIR/bin` and `libdedisp_test.a/so` will be placed in `INSTALL_DIR/lib`. CMake's usual boiler plate configuration files are in the CMake default paths.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and optional install path
             -DDEDISP_BUILD_TESTS=ON \
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_CUDA_ARCHITECTURES=70 \
-            -DCMAKE_INSTALL_PREFIX="/scratch/CPviolator/work/DSA110/dedisp_local/install" \
+            -DCMAKE_INSTALL_PREFIX="/path/to/install" \
             -DCMAKE_CUDA_COMPILER="/path/to/nvcc" ../dedisp`
 
 Alternatively, use the CMake GUI via

--- a/README.md
+++ b/README.md
@@ -1,13 +1,37 @@
 # dedisp
 This repositry is derived from Ben Barsdell's original GPU De-dedispersion library (code.google.com/p/dedisp)
 
-Installation Instructions:
+Installation Instructions (CMake):
 
-  1.  git clone https://github.com/ajameson/dedisp.git
-  2.  Update Makefile.inc with your CUDA path, Install Dir and GPU architecture. e.g.
-      * CUDA_PATH ?= /usr/local/cuda-8.0.61
-      * INSTALL_DIR = $(HOME)/opt/dedisp
-      * GPU_ARCH = sm_60
-  3.  make && make install
+Using command line CMake
+
+  1. `git clone https://github.com/ajameson/dedisp.git`
+  2. `mkdir build; cd build`
+
+Using command line CMake, choose relevant ON/OFF values, ## two digit CUDA architecture,
+and optional install path
+
+  3. `cmake -DDEDISP_USE_TEXTURE=ON \
+            -DDEDISP_BUILD_TESTS=ON \
+            -DCMAKE_CUDA_ARCHITECTURES=70 \
+            -DCMAKE_INSTALL_PREFIX="/scratch/CPviolator/work/DSA110/dedisp_local/install" \
+            -DCMAKE_CUDA_COMPILER="/path/to/nvcc" ../dedisp`
+
+Alternatively, use the CMake GUI via
+
+  3. `ccmake ../dedisp`
+
+Last, make (and install) the componenets
+
+  4. `make -j install`
+
+Using Makefile
+
+  1.  `git clone https://github.com/ajameson/dedisp.git`
+  2.  Update `Makefile.inc` with your CUDA path, Install Dir and GPU architecture. e.g.
+      * `CUDA_PATH ?= /usr/local/cuda-12.4`
+      * `INSTALL_DIR = $(HOME)/opt/dedisp`
+      * `GPU_ARCH = sm_60`
+  3.  `make && make install`
   
-  This will build a shared object library named libdedisp.so which is a prerequisite for Heimdall. The dedisp header files will be installed into INSTALL_DIR/include and the library into INSTALL_DIR/lib.
+  Either of these will build a shared object library named `libdedisp.so` which is a prerequisite for Heimdall. The dedisp header files will be installed into `INSTALL_DIR/include`, the test and runtime library into `INSTALL_DIR/lib` and the test executable into `INSTALL_DIR/bin`. The `CMake` method will build a static libray `libdedisp.a` in addition to `libdedisp.so` 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -5,8 +5,9 @@ set (DEDISP_TEST_OBJS
   ran1.c
   )
 
-# generate a cmake object library for all test files
+# generate libs
 add_library(dedisp_test ${DEDISP_TEST_OBJS})
+set_target_properties(dedisp_test PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
 
 add_executable(testdedisp testdedisp.c)
 target_link_libraries(testdedisp PUBLIC dedisp dedisp_test -lm)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -9,4 +9,4 @@ set (DEDISP_TEST_OBJS
 add_library(dedisp_test ${DEDISP_TEST_OBJS})
 
 add_executable(testdedisp testdedisp.c)
-target_link_libraries(testdedisp PUBLIC dedisp dedisp_test)
+target_link_libraries(testdedisp PUBLIC dedisp dedisp_test -lm)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,12 @@
+include_directories(../src)
+
+set (DEDISP_TEST_OBJS
+  gasdev.c
+  ran1.c
+  )
+
+# generate a cmake object library for all test files
+add_library(dedisp_test ${DEDISP_TEST_OBJS})
+
+add_executable(testdedisp testdedisp.c)
+target_link_libraries(testdedisp PUBLIC dedisp dedisp_test)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(../src)
+include_directories(${PROJECT_SOURCE_DIR}/src)
 
 set (DEDISP_TEST_OBJS
   gasdev.c
@@ -10,3 +10,9 @@ add_library(dedisp_test ${DEDISP_TEST_OBJS})
 
 add_executable(testdedisp testdedisp.c)
 target_link_libraries(testdedisp PUBLIC dedisp dedisp_test -lm)
+
+# Install library
+install(TARGETS dedisp_test LIBRARY DESTINATION lib)
+
+# Install executables
+install(TARGETS testdedisp RUNTIME DESTINATION bin)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,17 +1,18 @@
+# Object files
 set (DEDISP_OBJS
   dedisp.cu
   )
 
-# generate a cmake object library for all cu files
-add_library(dedisp ${DEDISP_OBJS})
-
-# make one library
-set(DEDISP_LIB dedisp)
-
-# Install headers
+# Headers
 set(DEDISP_HEADERS
   dedisp.h
   )
+
+# generate libs
+add_library(dedisp ${DEDISP_OBJS})
+set_target_properties(dedisp PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
+
+# Install headers
 install(FILES ${DEDISP_HEADERS} DESTINATION include)
 
 # Install lib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,9 @@
+set (DEDISP_OBJS
+  dedisp.cu
+  )
+
+# generate a cmake object library for all cu files
+add_library(dedisp ${DEDISP_OBJS})
+
+# make one library
+set(DEDISP_LIB dedisp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,3 +7,12 @@ add_library(dedisp ${DEDISP_OBJS})
 
 # make one library
 set(DEDISP_LIB dedisp)
+
+# Install headers
+set(DEDISP_HEADERS
+  dedisp.h
+  )
+install(FILES ${DEDISP_HEADERS} DESTINATION include)
+
+# Install lib
+install(TARGETS dedisp LIBRARY DESTINATION lib)


### PR DESCRIPTION
This PR adds CMake functionality to the library to allow easier compilation up the dependency tree. It also offers some initial texture object support, retains texture reference and no texture use support.

Texture object and reference distinction is deduced at compile time, and texture use is configurable via:

1. The CMake option `DEDISP_TEXTURE` which can be set using `ccmake` GIU
2. The command line `cmake -DDEDISP_TEXTURE ON`
3. Setting the envar  `export DEDISP_USE_TEXTURE=1` at compile time.

NOTE: Texture creation and destruction is done wholly in the `src/kernels.cuh` function `dedisperse`, which may not be the most efficient. Feedback on this to address performance is appreciated and any required changed will be implemented.

TODO:

- [x]  Add installation functionality to CMake (61883d708f3ea48ec3979c9fe210793687cf018b)
- [ ]  Check performance regression